### PR TITLE
Fix: classify.py reads artifact_size but fetch_prs.py writes artifact_bytes

### DIFF
--- a/scripts/classify.py
+++ b/scripts/classify.py
@@ -311,8 +311,8 @@ def _is_incomplete(pr: dict[str, Any]) -> tuple[bool, list[str]]:
         flags.append(f"seeds-only-{seeds}")
 
     # Artifact must be known — None means it was never parsed from the PR body.
-    # The pipeline sets artifact_size=None when the artifact field was "?" or missing.
-    artifact_size = pr.get("artifact_size")
+    # The pipeline sets artifact_bytes (or legacy artifact_size) to None when missing.
+    artifact_size = pr.get("artifact_bytes", pr.get("artifact_size"))
     if artifact_size is None:
         flags.append("artifact-unknown")
 


### PR DESCRIPTION
## Bug

`fetch_prs.py` writes artifact sizes to `artifact_bytes` (line 301), but `classify.py` reads `artifact_size` (line 315), which is never populated. Every open PR without banned-keyword flags gets classified as INCOMPLETE with `artifact-unknown`, even when artifact data exists.

Currently 0/641 INCOMPLETE PRs can become ALIVE... only merged PRs bypass the check.

## Fix

```python
# before
artifact_size = pr.get("artifact_size")

# after
artifact_size = pr.get("artifact_bytes", pr.get("artifact_size"))
```

Reads the field `fetch_prs.py` actually writes, with fallback for backwards compatibility.

See also: #4